### PR TITLE
Added parallel sort -- removed extra import

### DIFF
--- a/taco/lib/aggregate.py
+++ b/taco/lib/aggregate.py
@@ -21,7 +21,7 @@ __email__ = "mkiyer@umich.edu"
 __status__ = "Development"
 
 
-def aggregate(samples, ref_gtf_file, gtf_expr_attr, tmp_dir,
+def aggregate(args, samples, ref_gtf_file, gtf_expr_attr, tmp_dir,
               output_gtf_file, stats_file):
     '''
     Aggregate/merge individual sample GTF files
@@ -43,7 +43,7 @@ def aggregate(samples, ref_gtf_file, gtf_expr_attr, tmp_dir,
 
     # sort merged gtf
     logging.info("Sorting GTF")
-    retcode = sort_gtf(tmp_file, output_gtf_file, tmp_dir=tmp_dir)
+    retcode = sort_gtf(args, tmp_file, output_gtf_file, tmp_dir=tmp_dir)
     if retcode != 0:
         logging.error("Error sorting GTF")
         if os.path.exists(output_gtf_file):

--- a/taco/lib/run.py
+++ b/taco/lib/run.py
@@ -369,7 +369,8 @@ class Run(object):
         a = self.args
         samples = self.samples
 
-        aggregate(samples,
+        aggregate(self.args,
+                  samples,
                   ref_gtf_file=a.ref_gtf_file,
                   gtf_expr_attr=a.gtf_expr_attr,
                   tmp_dir=r.tmp_dir,


### PR DESCRIPTION
Checks for an implementation of parallel sort and uses it if it exists.

(Note: on macs, GNU Coreutils is installed as `gsort` instead of `sort`)