### PR TITLE
Fixes module import error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ def main():
           platforms='Linux',
           url='https://github.com/yniknafs/taco',
           ext_modules=extensions + cythonize(cython_extensions),
-          packages=['taco', 'taco.lib', 'taco.lib.bx', 'taco.lib.scipy'],
+          packages=['taco', 'taco.lib', 'taco.lib.bx', 'taco.lib.scipy', 'taco.lib.pysam'],
           scripts=['taco/taco_run.py'])
 
 


### PR DESCRIPTION
This fixes a module import error (Tested in Ubuntu 15.10 and OSX)

```
sudo python taco/taco_run.py 
Traceback (most recent call last):
  File "taco/taco_run.py", line 11, in <module>
    from taco.lib.run import Run
  File "/usr/local/lib/python2.7/dist-packages/taco/lib/run.py", line 14, in <module>
    from aggregate import aggregate_parallel
  File "/usr/local/lib/python2.7/dist-packages/taco/lib/aggregate.py", line 11, in <module>
    from taco.lib.pysam.cfaidx import FastaFile
ImportError: No module named pysam.cfaidx

```
